### PR TITLE
feature: 테스트 코드 작성 (특정 법정동코드 + 입력한 연월 기간 내 거래 내역 API 호출 및 DB 저장)

### DIFF
--- a/src/test/java/com/lighthouse/transactions/service/ApiServiceTest.java
+++ b/src/test/java/com/lighthouse/transactions/service/ApiServiceTest.java
@@ -3,6 +3,7 @@ package com.lighthouse.transactions.service;
 import com.lighthouse.config.EnvLoader;
 import com.lighthouse.config.RootConfig;
 import com.lighthouse.security.config.SecurityConfig;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,6 +14,11 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 
+import java.time.YearMonth;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.function.BiConsumer;
+
 @ExtendWith(SpringExtension.class)
 @WebAppConfiguration
 @ContextConfiguration(classes = { RootConfig.class, SecurityConfig.class }, initializers = EnvLoader.class)
@@ -22,6 +28,14 @@ class ApiServiceTest {
 
     @Autowired
     ApiService service;
+
+    @Test
+    @DisplayName("법정동코드 조회 테스트")
+    void insertLawdCd() {
+        int pageNo = 3;
+        int numOfRow = 1000;
+        service.insertLawdCd(pageNo, numOfRow);
+    }
 
     @Test
     @DisplayName("아파트 매매 조회 테스트")
@@ -138,11 +152,47 @@ class ApiServiceTest {
         service.insertSHRentalsToEstApiIntg(lawdCd, dealYmd);
     }
 
+    // API 명 + 실행 함수 매핑 클래스
+    @AllArgsConstructor
+    static class ApiNameCall {
+        String apiName;
+        BiConsumer<Integer, Integer> apiCall;
+    }
+
     @Test
-    @DisplayName("법정동코드 조회 테스트")
-    void insertLawdCd() {
-        int pageNo = 3;
-        int numOfRow = 1000;
-        service.insertLawdCd(pageNo, numOfRow);
+    @DisplayName("모든 API 삽입 테스트:  법정동코드, 시작~종료 연월까지 5초 간격 호출")
+    void insertAllApiToEstApiIntgTest() throws InterruptedException{
+        int lawdCd = 41210; // 광명시:41210, 하남시:41450, 거제시:48310
+        int startYmd = 202401;
+        int endYmd = 202412;
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMM");
+        YearMonth start = YearMonth.parse(String.valueOf(startYmd), formatter);
+        YearMonth end = YearMonth.parse(String.valueOf(endYmd), formatter);
+        // API 함수 목록
+        List<ApiNameCall> apiList = List.of(
+            new ApiNameCall("아파트 매매", service::insertAptTradesToEstApiIntg),
+            new ApiNameCall("아파트 전월세", service::insertAptRentalsToEstApiIntg),
+            new ApiNameCall("오피스텔 매매", service::insertOffTradesToEstApiIntg),
+            new ApiNameCall("오피스텔 전월세", service::insertOffRentalsToEstApiIntg),
+            new ApiNameCall("연립다세대 매매", service::insertMHTradesToEstApiIntg),
+            new ApiNameCall("연립다세대 전월세", service::insertMHRentalsToEstApiIntg),
+            new ApiNameCall("단독/다가구 매매", service::insertSHTradesToEstApiIntg),
+            new ApiNameCall("단독/다가구 전월세", service::insertSHRentalsToEstApiIntg)
+        );
+
+        for (YearMonth current = start; !current.isAfter(end); current = current.plusMonths(1)) {
+            int dealYmd = Integer.parseInt(current.format(formatter));
+            log.info("법정동코드: {}, 연월: {}", lawdCd, dealYmd);
+            for (ApiNameCall api: apiList) {
+                try {
+                    log.info("{} 호출", api.apiName);
+                    api.apiCall.accept(lawdCd, dealYmd);
+                    log.info("{} 완료", api.apiName);
+                } catch (Exception e) {
+                    log.error("{} 실패 - 법정동코드: {}, 연월: {}", api.apiName, lawdCd, dealYmd, e);
+                    throw e;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## 🔍 관련 이슈
- closes: #44

## ✅ 작업 내역
- `estate_api_integration_tbl` 및 `estate_api_integration_sales_tbl`에 한 지역 (법정코드 기준)의 지정한 기간 (연월) 내 데이터를 한 번에 넣을 수 있는 테스트 코드 작성

## 📎 기타 참고 사항
### 20250731 기준 DB 데이터 현황
`estate_api_integration_tbl` 및 `estate_api_integration_sales_tbl
`
- 거제시 (48310) - 2024년 6월
- 하남시 (41450) - 2024년 7월 ~ 2025년 6월
- 광명시 (41210) - 2024년 1월 ~ 2024년 12월