### PR TITLE
Hotfix: EstateDomain에서 /api 누락됨

### DIFF
--- a/src/main/java/com/lighthouse/estate/controller/EstateController.java
+++ b/src/main/java/com/lighthouse/estate/controller/EstateController.java
@@ -21,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/estate")
+@RequestMapping("/api/estate")
 @Api(tags="Estate 정보 조회")
 public class EstateController {
   private final EstateService estateService;


### PR DESCRIPTION
## 🔍 관련 이슈
단순수정

## ✅ 작업 내역
EstateController에서 엔드포인드 /api 누락되어 추가함