### PR TITLE
Chore: 비밀번호 유효성 검사 임시 주석처리

### DIFF
--- a/src/main/java/com/lighthouse/member/controller/MemberController.java
+++ b/src/main/java/com/lighthouse/member/controller/MemberController.java
@@ -102,9 +102,9 @@ public class MemberController {
             return ResponseEntity.ok().body(ApiResponse.error(ErrorCode.INVALID_EMAIL_FORMAT));
         }
         // 비밀번호 형식 유효성 검사
-        if (!memberService.isValidPassword(registerDto.getPassword1())) {
-            return ResponseEntity.ok().body(ApiResponse.error(ErrorCode.INVALID_PASSWORD_FORMAT));
-        }
+//        if (!memberService.isValidPassword(registerDto.getPassword1())) {
+//            return ResponseEntity.ok().body(ApiResponse.error(ErrorCode.INVALID_PASSWORD_FORMAT));
+//        }
         // 비밀번호1과 비밀번호2 일치 여부 검사
         if (!Objects.equals(registerDto.getPassword1(), registerDto.getPassword2())) {
             return ResponseEntity.ok().body(ApiResponse.error(ErrorCode.INVALID_PASSWORD_CHECK));


### PR DESCRIPTION
## 🔍 관련 이슈
- closes: #66

## ✅ 작업 내역
- 이메일 회원가입 시 비밀번호 형식 검사 임시 제거 (주석처리)

## 📎 기타 참고 사항
- 이메일 회원가입 시 비밀번호 유효성 검사 (영문 대/소문자, 숫자, 특수문자 각각 1개 이상, 총 8자 이상) 안 거치는지 테스트 요망