### PR TITLE
Fix: 프로필사진 변경 시 기존 프로필사진 파일 삭제

### DIFF
--- a/src/main/java/com/lighthouse/member/service/FileUploadService.java
+++ b/src/main/java/com/lighthouse/member/service/FileUploadService.java
@@ -54,7 +54,6 @@ public class FileUploadService {
             Path destinationPath = profileDir.resolve(uniqueFileName);
             file.transferTo(destinationPath.toFile());
             // 회원에게 반환할 URL 경로 생성
-//            String fileUrl = profileDir.resolve(uniqueFileName).toString().replace("\\", "/");
             String fileUrl = "/" + relativeUploadDir + "/profile/" + uniqueFileName;
             log.info("프로필사진 업로드 완료 - 파일: {}, URL: {}", uniqueFileName, fileUrl);
             return fileUrl;

--- a/src/main/java/com/lighthouse/member/service/MemberService.java
+++ b/src/main/java/com/lighthouse/member/service/MemberService.java
@@ -334,8 +334,9 @@ public class MemberService {
     public MemberResponseDTO uploadProfileImg(MemberResponseDTO memberDto, MultipartFile file) {
         try {
             Member member = memberMapper.findMemberById(memberDto.getId());
-            log.info("member: {}", member);
+            fileUploadService.deleteFile(member.getProfileImg());  // 기존 파일 삭제
             String uploadedImgUrl = fileUploadService.uploadProfileImg(file, memberDto.getId());
+            log.info("member: {}", member);
             log.info("uploadedImgUrl: {}", uploadedImgUrl);
             member.setProfileImg(uploadedImgUrl);
             memberMapper.updateMember(member);


### PR DESCRIPTION
## 🔍 관련 이슈
- closes: #88

## ✅ 작업 내역
- 프로필사진 변경 시 기존 프로필사진 파일 삭제 코드 추가