### PR TITLE
fix: 카카오 / 구글 로그인 수정

### DIFF
--- a/src/main/java/com/lighthouse/member/service/MemberService.java
+++ b/src/main/java/com/lighthouse/member/service/MemberService.java
@@ -233,10 +233,15 @@ public class MemberService {
             String kakaoNickname = kakaoUserClient.getKakaoNickname(kakaoAccessToken);
             member = dto.toMember();
             member.setName(kakaoNickname);
+            member.setEmail("");
             member.setKakaoId(kakaoUserId);
             member.setRegIp(clientIp);
             member.setRecentIp(clientIp);
+            member.setPwd("");
+            member.setGoogleId("");
+            member.setPhone("");
             memberMapper.insertMember(member);
+            member = memberMapper.findMemberByKakaoId(kakaoUserId);
         }
         // 토큰 발급 및 저장 (HttpOnly 쿠키, DB)
         int memberId = member.getId();
@@ -270,7 +275,11 @@ public class MemberService {
             member.setGoogleId(googleId);
             member.setRegIp(clientIp);
             member.setRecentIp(clientIp);
+            member.setPwd("");
+            member.setKakaoId("");
+            member.setPhone("");
             memberMapper.insertMember(member);
+            member = memberMapper.findMemberByGoogleId(googleId);
         }
         // 토큰 발급 및 저장 (HttpOnly 쿠키, DB)
         int memberId = member.getId();


### PR DESCRIPTION
카카오 로그인 시 not null인 값들에 "" 값 추가
저장된 회원 값을 가져와서 id 가져오기

## 🔍 관련 이슈
관련된 이슈 번호가 있다면 적어주세요. 자동 링크 가능
- closes: #10
- related to: #5

## ✅ 작업 내역
카카오 구글 로그인 로직 수정


## 📸 스크린샷(선택)
UI 변경 사항이 있다면 캡처해서 보여주세요


## 📎 기타 참고 사항
리뷰어가 참고하면 좋을 내용이 있다면 자유롭게 작성해주세요

ex)  
- security 로 로그인 정상 작동하는지 테스트 요망
  - ID: hong@gmail.com  
    PW: 1234  
    lighthouse_test 에 테스트 세팅 완료
