### PR TITLE
점수 계산 세부 수정

### DIFF
--- a/src/main/java/com/lighthouse/safereport/service/SafeReportService.java
+++ b/src/main/java/com/lighthouse/safereport/service/SafeReportService.java
@@ -352,10 +352,17 @@ public class SafeReportService {
     
     // 최종 점수 계산 (역전세율 점수 70% + 위반 점수 30%)
     private Integer calculateTotalScore(RentalRatioAndBuildyear rentalRatioAndBuildyear, ViolationStatus violationStatus) {
-        // 특별 케이스: 역전세율 점수가 0이고 위반 점수가 10점인 경우 최종 점수를 8점으로 설정
+        // 특별 케이스 1: 역전세율 점수가 0이고 위반 점수가 10점인 경우 최종 점수를 8점으로 설정
         if (rentalRatioAndBuildyear != null && rentalRatioAndBuildyear.getScore() == 0 && 
             violationStatus != null && violationStatus.getScore() == 10) {
             return 8;
+        }
+        
+        // 특별 케이스 2: 역전세율 점수가 10점이고 위반 점수가 3점인 경우 주의 등급(5~7점)으로 설정
+        if (rentalRatioAndBuildyear != null && rentalRatioAndBuildyear.getScore() == 10 && 
+            violationStatus != null && violationStatus.getScore() == 3) {
+            // 5~7점 사이의 랜덤한 점수 반환 (주의 등급)
+            return 6; // 중간값인 6점으로 설정
         }
         
         double totalScore = 0.0;

--- a/src/main/java/com/lighthouse/safereport/service/SafeReportService.java
+++ b/src/main/java/com/lighthouse/safereport/service/SafeReportService.java
@@ -352,6 +352,12 @@ public class SafeReportService {
     
     // 최종 점수 계산 (역전세율 점수 70% + 위반 점수 30%)
     private Integer calculateTotalScore(RentalRatioAndBuildyear rentalRatioAndBuildyear, ViolationStatus violationStatus) {
+        // 특별 케이스: 역전세율 점수가 0이고 위반 점수가 10점인 경우 최종 점수를 8점으로 설정
+        if (rentalRatioAndBuildyear != null && rentalRatioAndBuildyear.getScore() == 0 && 
+            violationStatus != null && violationStatus.getScore() == 10) {
+            return 8;
+        }
+        
         double totalScore = 0.0;
         int validFactors = 0;
         


### PR DESCRIPTION
## 🔍 관련 이슈
관련된 이슈 번호가 있다면 적어주세요. 자동 링크 가능
- closes: #10
- related to: #5

## ✅ 작업 내역

깡통전세 점수 0점이고 토지대장 점수 10점인 경우 기존에 3점으로 계산되던거 8점으로 조정



## 📸 스크린샷(선택)
UI 변경 사항이 있다면 캡처해서 보여주세요


## 📎 기타 참고 사항
리뷰어가 참고하면 좋을 내용이 있다면 자유롭게 작성해주세요

ex)  
- security 로 로그인 정상 작동하는지 테스트 요망
  - ID: hong@gmail.com  
    PW: 1234  
    lighthouse_test 에 테스트 세팅 완료
