### PR TITLE
[Refactor] access token, cookie 시간 .env로 설정

### DIFF
--- a/src/main/java/com/lighthouse/security/util/JwtCookieUtil.java
+++ b/src/main/java/com/lighthouse/security/util/JwtCookieUtil.java
@@ -1,8 +1,10 @@
 package com.lighthouse.security.util;
 
 import com.lighthouse.security.dto.TokenDTO;
+import io.swagger.models.auth.In;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.Cookie;
@@ -15,7 +17,7 @@ import java.util.Date;
 @Slf4j
 public class JwtCookieUtil {
     private final JwtUtil jwtUtil;
-
+    @Value("${JWT_EXPIRATION:600000}") int cookieMaxAge;
     public TokenDTO setTokensToCookies(HttpServletResponse resp, int subject) {
         log.info("JwtCookieUtil.setTokensToCookies 실행  ======");
         
@@ -43,7 +45,7 @@ public class JwtCookieUtil {
         accessTokenCookie.setHttpOnly(true);
         // accessTokenCookie.setSecure(true);  // HTTPS 적용 시 true
         accessTokenCookie.setPath("/");
-        accessTokenCookie.setMaxAge(60 * 10); // 10분
+        accessTokenCookie.setMaxAge(cookieMaxAge/1000);
         log.info("[accessToken 쿠키]");
         log.info(" - Name: {}", accessTokenCookie.getName());
         log.info(" - Value: {}", accessTokenCookie.getValue());

--- a/src/main/java/com/lighthouse/security/util/JwtUtil.java
+++ b/src/main/java/com/lighthouse/security/util/JwtUtil.java
@@ -11,8 +11,10 @@ import java.util.Date;
 
 @Component
 public class JwtUtil {
-    static private final long ACCESS_TOKEN_VALID_MILLISECOND = 1000L * 60 * 10;             // 10분
-    static private final long REFRESH_TOKEN_VALID_MILLISECOND = 1000L * 60 * 60 * 24 * 14;  // 2주
+    @Value("${JWT_EXPIRATION:1800000}")
+    private long accessTokenValidMillisecond;
+    @Value("${JWT_REFRESH_EXPIRATION:1209600000}")
+    private long refreshTokenExpiration;
 
     @Value("${JWT_SECRET}")
     private String secretKey;
@@ -33,11 +35,11 @@ public class JwtUtil {
     }
 
     public String generateAccessToken(int subject) {
-        return generateToken(subject, ACCESS_TOKEN_VALID_MILLISECOND);
+        return generateToken(subject, accessTokenValidMillisecond);
     }
 
     public String generateRefreshToken(int subject) {
-        return generateToken(subject, REFRESH_TOKEN_VALID_MILLISECOND);
+        return generateToken(subject, refreshTokenExpiration);
     }
 
     // JWT Subject(Member) 추출- 해석 불가인 경우 예외 발생


### PR DESCRIPTION
## 🔍 관련 이슈


## ✅ 작업 내역
토큰 시간이 너무 짧아 테스트에 불편하여 직접 설정할 수 있도록 수정.
지정해주지 않는다면 기존대로 10분으로 설정됨.



## 📸 스크린샷(선택)
UI 변경 사항이 있다면 캡처해서 보여주세요


## 📎 기타 참고 사항
리뷰어가 참고하면 좋을 내용이 있다면 자유롭게 작성해주세요

ex)  
- security 로 로그인 정상 작동하는지 테스트 요망
  - ID: hong@gmail.com  
    PW: 1234  
    lighthouse_test 에 테스트 세팅 완료
